### PR TITLE
Correct call_movers to avoid temp object

### DIFF
--- a/src/framework/board.cpp
+++ b/src/framework/board.cpp
@@ -21,8 +21,7 @@ MovesT Board::get_moves(Pos pos) const {
   auto moves = legal_move::_inner::get_moves_from_mover(*this, piece.value(), pos, mover);
   legal_move::_inner::insert(moves, legal_move::_inner::get_extra_moves(*this, piece.value(), pos));
 
-  // todo: avoid creating temp objects
-  call_movers(pos, moves, legal_move::MoverPawnAhead{});
+  call_movers<legal_move::MoverPawnAhead>(pos, moves);
 
   return moves;
 }

--- a/src/framework/board.hpp
+++ b/src/framework/board.hpp
@@ -50,12 +50,10 @@ class Board {
   MovesT get_moves(Pos pos) const;
 
   template <class T, class... REST>
-  void call_movers(Pos pos, MovesT& moves, T, REST... rest) const {
+  void call_movers(Pos pos, MovesT& moves) const {
     MovesT res = T::get_moves(*this, pos);
     moves.insert(end(moves), begin(res), end(res));
-    call_movers(pos, moves, rest...);
+    if constexpr (sizeof...(REST)) call_movers<REST...>(pos, moves);
   }
-
-  void call_movers(Pos pos, MovesT& moves) const {}
 };
 }  // namespace dwc


### PR DESCRIPTION
Correct call_movers to avoid temp object